### PR TITLE
Remove optional endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,12 @@ npm install @builton.dev/core-sdk
 
 ## Getting started
 
-`new Builton({ apiKey, bearerToken, endpoint })`
+`new Builton({ apiKey, bearerToken })`
 
-Initialises a new instance of `Builton` configured with your application `apiKey`, a `bearerToken` token from an authentication provider (optional) and the endpoint of your choice (generally `https://qa.builton.dev/` for our QA environment or `https://api.builton.dev/` for our production one).
+Initialises a new instance of `Builton` configured with your application `apiKey` and a `bearerToken` token from an authentication provider (optional).
 
 - **apiKey {String}**: Your attributed Builton API Key.
 - **bearerToken {String}** - *(optional)*: Your JSON Web Token (JWT), from your authentication provider.
-- **endpoint {String}**: The endpoint for the environment of your choice (generally `https://api.builton.dev/` or `https://qa.builton.dev/`).
 
 *Note: Accessing the API without a bearerToken will limit the number of endpoints and information you can access.*
 
@@ -68,8 +67,7 @@ lock.on("authenticated", function(authResult) {
 
     var builton = new Builton({
 	apiKey: 'YOUR_Builton_API_KEY',
-	bearerToken: authResult.idToken,
-	endpoint: 'https://qa.builton.dev/'
+	bearerToken: authResult.idToken
     });
 
     var loginBody = {
@@ -118,7 +116,6 @@ callbacks: {
 	  var builton = new Builton({
 		apiKey: config.apiKey,
 		bearerToken: idToken,
-		endpoint: config.endpoint,
 	  });
 	  const body = {
 		first_name: 'demo',

--- a/examples/auth0/config.example.js
+++ b/examples/auth0/config.example.js
@@ -1,6 +1,5 @@
 var config = {
   apiKey: 'YOUR_Builton_API_KEY',
-  endpoint: 'http://qa.builton.dev/',
   auth0: {
     client: 'YOUR_AUTH0_API_KEY',
     domain: 'YOUR_AUTH0_DOMAIN',

--- a/examples/auth0/index.html
+++ b/examples/auth0/index.html
@@ -34,8 +34,7 @@
 
     var builton = new Builton({
       apiKey: config.apiKey,
-      bearerToken: idToken,
-      endpoint: config.endpoint,
+      bearerToken: idToken
     });
 
     var loginBody = {

--- a/examples/firebase/config.example.js
+++ b/examples/firebase/config.example.js
@@ -1,6 +1,5 @@
 var config = {
   apiKey: 'YOUR_Builton_API_KEY',
-  endpoint: 'http://qa.builton.ai/',
   firebase: {
     apiKey: 'YOUR_FIREBASE_API_KEY',
     authDomain: 'YOUR_FIREBASE_AUTH_DOMAIN',

--- a/examples/firebase/index.html
+++ b/examples/firebase/index.html
@@ -33,8 +33,7 @@
         authResult.user.getIdToken().then((idToken) => {
           var builton = new Builton({
             apiKey: config.apiKey,
-            bearerToken: idToken,
-            endpoint: config.endpoint,
+            bearerToken: idToken
           });
           const body = {
             first_name: 'demo',

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ const Webhook = require('./collection/webhook');
 let instance;
 
 class Builton {
-  constructor({ apiKey, bearerToken, endpoint } = {}) {
+  constructor({ apiKey, bearerToken, endpoint = 'https://api.builton.dev/' } = {}) {
     if (instance) {
       return instance;
     }


### PR DESCRIPTION
Until now, the SDK required the user to configure an endpoint.
We removed the access to the QA endpoint for our customers, therefore the endpoint is now hard-coded in the SDK for easier use