### PR TITLE
Moved `body` and `search` out of parameter object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ lock.on("authenticated", function(authResult) {
       last_name: profile.family_name,
     };
 
-    builton.authenticate.login({ body: loginBody }, function(err, user, raw) {
+    builton.authenticate.login(loginBody, {}, function(err, user, raw) {
       // The raw parameter contains the full response of the query, it's optional but can be useful to access the response's headers.
 	  if (err) {
 		// Handle error
@@ -119,7 +119,7 @@ callbacks: {
 		first_name: 'demo',
 		last_name: 'demo',
 	  };
-	  builton.users.authenticate({ body }).then((user) => {
+	  builton.users.authenticate(body).then((user) => {
 		// Update DOM
 	  }).catch(console.warn);
 	});
@@ -143,9 +143,7 @@ Using a callback:
 builton.paymentMethods.get({ urlParams: { size: 5 } }, function(err, paymentMethods) {
   const firstPaymentMethod = paymentMethods[0];
   firstPaymentMethod.update({
-    body: {
-        token: ':StripeTokenId:'
-    }
+		token: ':StripeTokenId:'
   });
 });
 ```
@@ -155,9 +153,7 @@ Using promises:
 builton.paymentMethods.get({ urlParams: { size: 5 } }).then((paymentMethods) => {
   const firstPaymentMethod = paymentMethods[0];
   firstPaymentMethod.update({
-    body: {
-        token: ':StripeTokenId:'
-    }
+    token: ':StripeTokenId:'
   });
 });
 ```
@@ -168,9 +164,7 @@ Using async/await:
 const paymentMethods = await builton.paymentMethods.get({ urlParams: { size: 5 } });
 const firstPaymentMethod = paymentMethods[0];
 firstPaymentMethod.update({
-  body: {
-      token: ':StripeTokenId:'
-  }
+  token: ':StripeTokenId:'
 });
 ```
 
@@ -178,9 +172,7 @@ firstPaymentMethod.update({
 
 ```js
 builton.paymentMethods.update(':paymentMethodId:', {
-    body: {
-        token: ':StripeTokenId:'
-    }
+  token: ':StripeTokenId:'
 });
 ```
 
@@ -189,9 +181,7 @@ Using the `set` method:
 ```js
 const paymentMethod = builton.paymentMethods.set(':paymentMethodId:');
 paymentMethod.update({
-    body: {
-        token: ':StripeTokenId:'
-    }
+  token: ':StripeTokenId:'
 });
 ```
 
@@ -202,9 +192,7 @@ The `set` method allows you to create an object without fetching it from the api
 ```js
 const paymentMethod = builton.paymentMethods.set(':paymentMethodId:');
 paymentMethod.update({
-    body: {
-        token: ':StripeTokenId:'
-    }
+  token: ':StripeTokenId:'
 });
 ```
 
@@ -212,9 +200,7 @@ With multiple payment methods:
 ```js
 const paymentMethods = builton.paymentMethods.set([':paymentMethodId1:', ':paymentMethodId2:']);
 paymentMethods[0].update({
-    body: {
-        token: ':StripeTokenId:'
-    }
+  token: ':StripeTokenId:'
 });
 ```
 
@@ -222,9 +208,7 @@ With full props:
 ```js
 const paymentMethod = builton.paymentMethods.set({<paymentMethodJsonObject>});
 paymentMethod.update({
-    body: {
-        token: ':StripeTokenId:'
-    }
+  token: ':StripeTokenId:'
 });
 ```
 

--- a/examples/auth0/index.html
+++ b/examples/auth0/index.html
@@ -42,7 +42,7 @@
       last_name: profile.family_name,
     };
 
-    builton.users.authenticate({ body: loginBody }, function(err, user) {
+    builton.users.authenticate(loginBody, {}, function(err, user) {
       if (err) {
         // Handle error
         return;
@@ -50,7 +50,7 @@
 
       document.getElementById('profile').innerHTML = 'Hello ' + user.first_name + ' ' + user.last_name;
 
-      builton.products.search({query: 'test'}, function (err, products) {
+      builton.products.search('test', {}, function (err, products) {
         if (err) {
           // Handle error
           return;
@@ -68,7 +68,7 @@
             geo: [59.909848, 10.7379474],
           }
         };
-        builton.orders.create({body: orderBody}, function (err, order) {
+        builton.orders.create(orderBody, {}, function (err, order) {
           if (err) {
             // Handle error
             return;

--- a/examples/firebase/index.html
+++ b/examples/firebase/index.html
@@ -41,8 +41,8 @@
             first_name: 'demo',
             last_name: 'demo',
           };
-          builton.users.authenticate({ body }).then((user) => {
-            user.update({ body: { mobile_phone_number: phoneNumber } }).then(console.log).catch(console.warn);
+          builton.users.authenticate(body).then((user) => {
+            user.update({ mobile_phone_number: phoneNumber }).then(console.log).catch(console.warn);
           }).catch(console.warn);
         });
         // User successfully signed in.

--- a/examples/imageUpload/index.html
+++ b/examples/imageUpload/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
  <head>
-  <script src="https://unpkg.com/@builton/core-sdk@latest/dist/main.bundle.js"></script>
+  <script src="../../dist/main.bundle.js"></script>
  </head>
  <body>
    <form id="uploadForm">
@@ -20,11 +20,11 @@
     e.preventDefault();
     const imageData = document.getElementById("image").files[0];
     try {
-      const image = await b.images.create({ imageData, isPublic: true });
-      const imageUrl = "https://qa.builton.dev/images/" + image.url + "?api_key=" + apiKey;
+      const image = await b.images.create(imageData, { isPublic: true });
+      const imageUrl = "https://builton.dev/images/" + image.url + "?api_key=" + apiKey;
       document.getElementById("imageContainer").innerHTML = "<img src=\"" + imageUrl + "\" />";
       const user = b.users.setMe();
-      user.update({ body: { avatar: image.url } });
+      user.update({ avatar: image.url });
     } catch(e) {
       console.error(e);
     }

--- a/src/collection/objects/_methods.js
+++ b/src/collection/objects/_methods.js
@@ -12,7 +12,7 @@ module.exports = {
     return this.get({ urlParams, json }, done);
   },
 
-  update({ body, urlParams, json = false } = {}, done) {
+  update(body, { urlParams, json = false } = {}, done) {
     return this.query({
       type: 'put',
       id: this.id,

--- a/src/collection/objects/aiModel.js
+++ b/src/collection/objects/aiModel.js
@@ -9,7 +9,7 @@ class AIModel extends Component {
     this.apiPath = 'ai/models';
   }
 
-  getRecommendations({ body, urlParams } = {}, done) {
+  getRecommendations(body, { urlParams } = {}, done) {
     return this.query({
       type: 'post', resource: 'invoke', body, urlParams, ResConstructor: null,
     }, done);

--- a/src/collection/objects/order.js
+++ b/src/collection/objects/order.js
@@ -33,19 +33,19 @@ class Order extends Component {
     }, done);
   }
 
-  pay({ body, urlParams, json = false } = {}, done) {
+  pay(body, { urlParams, json = false } = {}, done) {
     return this.query({
       type: 'post', resource: 'pay', body, urlParams, json,
     }, done);
   }
 
-  redeem({ body, urlParams, json = false } = {}, done) {
+  redeem(body, { urlParams, json = false } = {}, done) {
     return this.query({
       type: 'post', resource: 'redeem', body, urlParams, json,
     }, done);
   }
 
-  cancel({ body, urlParams, json = false } = {}, done) {
+  cancel(body, { urlParams, json = false } = {}, done) {
     return this.query({
       type: 'post',
       resource: 'cancel',
@@ -55,7 +55,7 @@ class Order extends Component {
     }, done);
   }
 
-  createDelivery({ body, urlParams } = {}, done) {
+  createDelivery(body, { urlParams } = {}, done) {
     return this.query({
       type: 'post',
       resource: 'deliveries',
@@ -65,7 +65,7 @@ class Order extends Component {
     }, done);
   }
 
-  triggerDeliveryAction({ body, deliveryId, urlParams } = {}, done) {
+  triggerDeliveryAction(body, { deliveryId, urlParams } = {}, done) {
     if (!this.id) return done(new Error.MethodNeedsId());
     if (!deliveryId) return done(new Error.MethodNeedsArg('deliveryId'));
     const params = {

--- a/src/collection/objects/payment.js
+++ b/src/collection/objects/payment.js
@@ -11,13 +11,13 @@ class Payment extends Component {
     this.apiPath = 'payments';
   }
 
-  pay({ body, urlParams, json = false } = {}, done) {
+  pay(body, { urlParams, json = false } = {}, done) {
     return this.query({
       type: 'post', resource: 'pay', body, urlParams, json,
     }, done);
   }
 
-  confirm({ body, urlParams, json = false }, done) {
+  confirm(body, { urlParams, json = false } = {}, done) {
     return this.query({
       type: 'post', resource: 'confirm', body, urlParams, json,
     }, done);

--- a/src/collection/objects/plan.js
+++ b/src/collection/objects/plan.js
@@ -11,9 +11,9 @@ class Plan extends Component {
     this.apiPath = 'plans';
   }
 
-  getSubscriptions({ body, urlParams, json = false } = {}, done) {
+  getSubscriptions({ urlParams, json = false } = {}, done) {
     return this.query({
-      type: 'get', resource: 'subscriptions', body, urlParams, json, ResConstructor: Subscription,
+      type: 'get', resource: 'subscriptions', urlParams, json, ResConstructor: Subscription,
     }, done);
   }
 }

--- a/src/collection/objects/product.js
+++ b/src/collection/objects/product.js
@@ -16,9 +16,9 @@ class Product extends Component {
     }, done);
   }
 
-  searchSubProducts({ urlParams, json = false } = {}, done) {
+  searchSubProducts(query, { urlParams, json = false } = {}, done) {
     return this.query({
-      type: 'get', resource: 'sub_products/search', urlParams, json,
+      type: 'get', resource: 'sub_products/search', urlParams: Object.assign({}, urlParams, { query }), json,
     }, done);
   }
 }

--- a/src/collection/objects/subscription.js
+++ b/src/collection/objects/subscription.js
@@ -23,13 +23,13 @@ class Subscription extends Component {
     }, done);
   }
 
-  start({ body, urlParams, json = false } = {}, done) {
+  start(body, { urlParams, json = false } = {}, done) {
     return this.query({
       type: 'post', id: this.id, resource: 'start', body, urlParams, json,
     }, done);
   }
 
-  stop({ body, urlParams, json = false } = {}, done) {
+  stop(body, { urlParams, json = false } = {}, done) {
     return this.query({
       type: 'post', id: this.id, resource: 'stop', body, urlParams, json,
     }, done);

--- a/src/collection/objects/user.js
+++ b/src/collection/objects/user.js
@@ -29,19 +29,19 @@ class User extends Component {
     }, done);
   }
 
-  setRating({ body, urlParams } = {}, done) {
+  setRating(body, { urlParams } = {}, done) {
     return this.query({
       type: 'put', id: this.id, resource: 'ratings', body, urlParams, ResConstructor: null,
     }, done);
   }
 
-  updateAddresses({ body, urlParams } = {}, done) {
+  updateAddresses(body, { urlParams } = {}, done) {
     return this.query({
       type: 'put', id: this.id, resource: 'addresses', body, urlParams, ResConstructor: null,
     }, done);
   }
 
-  getSubscriptions({ body, urlParams } = {}, done) {
+  getSubscriptions(body, { urlParams } = {}, done) {
     return this.query({
       type: 'get', id: this.id, resource: 'subscriptions', body, urlParams, ResConstructor: Subscription,
     }, done);

--- a/src/collection/resources/_methods.js
+++ b/src/collection/resources/_methods.js
@@ -30,7 +30,7 @@ module.exports = ObjectClass => ({
     return obj.update(...params);
   },
 
-  create({ body, urlParams, json = false } = {}, done) {
+  create(body, { urlParams, json = false } = {}, done) {
     return this.query({
       type: 'post',
       urlParams,
@@ -39,7 +39,7 @@ module.exports = ObjectClass => ({
     }, done);
   },
 
-  search({ query, urlParams, json = false } = {}, done) {
+  search(query, { urlParams, json = false } = {}, done) {
     return this.query({
       type: 'get', action: 'search', urlParams: Object.assign({}, urlParams, { query }), json,
     }, done);

--- a/src/collection/resources/images.js
+++ b/src/collection/resources/images.js
@@ -10,7 +10,7 @@ class Images extends Components {
     this.ResConstructor = Image;
   }
 
-  create({ imageData, isPublic, urlParams } = {}, done) {
+  create(imageData, { isPublic, urlParams } = {}, done) {
     const form = new FormData();
     form.append('image', imageData);
     if (isPublic !== undefined) {

--- a/src/collection/resources/products.js
+++ b/src/collection/resources/products.js
@@ -15,6 +15,16 @@ class Products extends Components {
     this.apiPath = 'products';
     this.ResConstructor = Product;
   }
+
+  getSubProducts(id, ...params) {
+    const obj = new Product(this.request, id);
+    return obj.getSubProducts(...params);
+  }
+
+  searchSubProducts(id, ...params) {
+    const obj = new Product(this.request, id);
+    return obj.searchSubProducts(...params);
+  }
 }
 
 module.exports = Products;

--- a/src/collection/resources/users.js
+++ b/src/collection/resources/users.js
@@ -19,14 +19,15 @@ class Users extends Components {
 
   // The `Create` and the `Authenticate` functions are functionnaly identical.
   // No need to `Authenticate` after `Create`.
-  create({ body, urlParams, json = false } = {}, done) {
+  create(body, { urlParams, json = false } = {}, done) {
+    console.log(body, urlParams, json, done);
     return this.query({
       type: 'post', apiPath: 'v2/users', urlParams, body, json,
     }, done);
   }
 
-  authenticate({ body, urlParams, json = false } = {}, done) {
-    return this.create({ body, urlParams, json }, done);
+  authenticate(body, { urlParams, json = false } = {}, done) {
+    return this.create(body, { urlParams, json }, done);
   }
 
   getOrders(id, ...params) {

--- a/test/collection/aiModel.js
+++ b/test/collection/aiModel.js
@@ -37,7 +37,7 @@ describe('AI', () => {
     it('Should create a new ai model based on type, source and destination', (done) => {
       url = `${endpoint}ai/models`;
       mock.post(url, () => ({ body: modelCreatedFile, ok: true }));
-      sa.aiModels.create({ model_type: 'content_recommender', source: 'product', destination: 'product' }, (err, model) => {
+      sa.aiModels.create({ model_type: 'content_recommender', source: 'product', destination: 'product' }, {}, (err, model) => {
         if (err) throw err;
         assert.ok(model.constructor.name === 'AIModel');
         assert.ok(model.training_status === 'CREATED');
@@ -63,7 +63,7 @@ describe('AI', () => {
     it('Should return recommendation for a given source based on a specific model', (done) => {
       url = `${endpoint}ai/models/:modelId/invoke`;
       mock.post(url, () => ({ body: recommendationsFile, ok: true }));
-      sa.aiModels.set(':modelId:').getRecommendations({ source_id: '5aec176d1f7cdc0008848f87', size: 4 }, (err, recommendations) => {
+      sa.aiModels.set(':modelId:').getRecommendations({ source_id: '5aec176d1f7cdc0008848f87', size: 4 }, {}, (err, recommendations) => {
         if (err) throw err;
         assert.ok(Array.isArray(recommendations.response));
         done();

--- a/test/collection/image.js
+++ b/test/collection/image.js
@@ -19,7 +19,7 @@ describe('Image related tests', () => {
     url = `${endpoint}images`;
     mock.post(url, () => ({ body: imageFile, ok: true }));
     const imageData = fs.createReadStream('../fetchmock/1x1.png');
-    const image = await sa.images.create({ imageData });
+    const image = await sa.images.create(imageData);
     assert.equal(image.original_name, '1x1.png');
     return true;
   });

--- a/test/collection/order.js
+++ b/test/collection/order.js
@@ -71,7 +71,7 @@ describe('Order', () => {
   it('Should update an order', (done) => {
     url = `${endpoint}orders/:orderId:`;
     mock.put(url, () => ({ body: orderFile, ok: true }));
-    sa.orders.set(':orderId:').update({ body: { delivery_status: 'ACCEPTED' } }, (err, order) => {
+    sa.orders.set(':orderId:').update({ delivery_status: 'ACCEPTED' }, {}, (err, order) => {
       if (err) throw err;
       assert.ok(order.constructor.name === 'Order');
       assert.ok((order.human_id === 'Y8RDPJ'));
@@ -82,7 +82,7 @@ describe('Order', () => {
   it('Should post an order', (done) => {
     url = `${endpoint}orders`;
     mock.post(url, () => ({ body: orderFile, ok: true }));
-    sa.orders.create(orderPostBody, (err, order) => {
+    sa.orders.create(orderPostBody, {}, (err, order) => {
       if (err) throw err;
       assert.ok(order.constructor.name === 'Order');
       assert.ok((order.human_id === 'Y8RDPJ'));
@@ -121,7 +121,7 @@ describe('Order', () => {
   it('Should submit a delivery', (done) => {
     url = `${endpoint}orders/:orderId:/deliveries/:deliveryId:`;
     mock.post(url, () => ({ body: deliveryFile, ok: true }));
-    sa.orders.set(':orderId:').triggerDeliveryAction({ deliveryId: ':deliveryId:' }, (err, delivery) => {
+    sa.orders.set(':orderId:').triggerDeliveryAction({}, { deliveryId: ':deliveryId:' }, (err, delivery) => {
       if (err) throw err;
       assert.ok(delivery.status === deliveryFile.status);
       done();
@@ -131,7 +131,7 @@ describe('Order', () => {
   it('Should submit a delivery', (done) => {
     url = `${endpoint}orders/:orderId:/deliveries/:deliveryId:`;
     mock.post(url, () => ({ body: deliveryFile, ok: true }));
-    sa.orders.triggerDeliveryAction(':orderId:', { deliveryId: ':deliveryId:' }, (err, delivery) => {
+    sa.orders.triggerDeliveryAction(':orderId:', {}, { deliveryId: ':deliveryId:' }, (err, delivery) => {
       if (err) throw err;
       assert.ok(delivery.status === deliveryFile.status);
       done();

--- a/test/collection/payment.js
+++ b/test/collection/payment.js
@@ -25,10 +25,8 @@ describe('Payment related tests', () => {
     url = `${endpoint}payments/:paymentId:/confirm`;
     mock.post(url, () => ({ body: paymentConfirmedFile, ok: true }));
     const payment = await sa.payments.set(':paymentId:').confirm({
-      body: {
-        payment_intent_id: ':payment_intent_id:',
-        payment_client_secret: ':payment_client_secret:',
-      },
+      payment_intent_id: ':payment_intent_id:',
+      payment_client_secret: ':payment_client_secret:',
     });
     assert.ok(paymentConfirmedFile._id.$oid === payment._id.$oid);
   });

--- a/test/collection/paymentMethod.js
+++ b/test/collection/paymentMethod.js
@@ -24,14 +24,14 @@ describe('Payment methods related tests', () => {
     url = `${endpoint}payment_methods`;
     mock.post(url, () => ({ body: paymentMethodWithIntent, ok: true }));
 
-    const paymentMethod = await sa.paymentMethods.create({ body: { payment_method: 'stripe' } });
+    const paymentMethod = await sa.paymentMethods.create({ payment_method: 'stripe' });
     assert.ok(paymentMethod._id.$oid === paymentMethodWithIntent._id.$oid);
   });
   it('Should update an exisiting payment method with Stripe payment method id', async () => {
     url = `${endpoint}payment_methods/fake_id`;
     mock.put(url, () => ({ body: paymentMethodWithCard, ok: true }));
 
-    const paymentMethod = await sa.paymentMethods.set('fake_id').update({ body: { payment_method_id: 'pm_fake_payment_method_id' } });
+    const paymentMethod = await sa.paymentMethods.set('fake_id').update({ payment_method_id: 'pm_fake_payment_method_id' });
     assert.ok(paymentMethod.source === 'pm_fake_payment_method_id');
     assert.ok(paymentMethod.card);
     assert.ok(paymentMethod.is_sca_compatible);

--- a/test/collection/product.js
+++ b/test/collection/product.js
@@ -50,7 +50,16 @@ describe('Product related tests', () => {
   it('Should search products', (done) => {
     url = `${endpoint}products/search?page=2&query=searchQuery`;
     mock.get(url, () => ({ body: productsFile, ok: true }));
-    sa.products.search({ query: 'searchQuery', urlParams: { page: 2 } }, (err, products) => {
+    sa.products.search('searchQuery', { urlParams: { page: 2 } }, (err, products) => {
+      assert.ok(Array.isArray(products));
+      assert.ok(products[0].constructor.name === 'Product');
+      done();
+    });
+  });
+  it('Should search subproducts for a product', (done) => {
+    url = `${endpoint}products/:id:/sub_products/search?query=searchQuery`;
+    mock.get(url, () => ({ body: productsFile, ok: true }));
+    sa.products.searchSubProducts(':id:', 'searchQuery', {}, (err, products) => {
       assert.ok(Array.isArray(products));
       assert.ok(products[0].constructor.name === 'Product');
       done();

--- a/test/collection/subscription.js
+++ b/test/collection/subscription.js
@@ -33,11 +33,9 @@ describe('Subscription related tests', () => {
     mock.post(url, () => ({ body: subscriptionFile, ok: true }));
 
     sa.subscriptions.set(':subscriptionId:').start({
-      body: {
-        payment_method: 'dummy_payment_method',
-        subscription_method: 'dummy_subscription_method',
-      },
-    }, (err, subscription) => {
+      payment_method: 'dummy_payment_method',
+      subscription_method: 'dummy_subscription_method',
+    }, {}, (err, subscription) => {
       assert.ok((subscription.name === subscriptionFile.name));
       assert.ok(subscription.constructor.name === 'Subscription');
       done();
@@ -48,7 +46,7 @@ describe('Subscription related tests', () => {
     url = `${endpoint}subscriptions/:subscriptionId:/stop`;
     mock.post(url, () => ({ body: subscriptionFile, ok: true }));
 
-    sa.subscriptions.set(':subscriptionId:').stop({}, (err, subscription) => {
+    sa.subscriptions.set(':subscriptionId:').stop({}, {}, (err, subscription) => {
       assert.ok((subscription.name === subscriptionFile.name));
       assert.ok(subscription.constructor.name === 'Subscription');
       done();
@@ -59,7 +57,7 @@ describe('Subscription related tests', () => {
     url = `${endpoint}subscriptions/:subscriptionId:`;
     mock.put(url, () => ({ body: subscriptionFile, ok: true }));
 
-    const updatedSubscription = await sa.subscriptions.set(':subscriptionId:').update({ body: { payment_method: '<payment-method-id>' } });
+    const updatedSubscription = await sa.subscriptions.set(':subscriptionId:').update({ payment_method: '<payment-method-id>' });
     assert.ok(updatedSubscription.payment_method.$oid === '<payment-method-id>');
   });
 });


### PR DESCRIPTION
Any function requiring a `body` parameter are currently similar to:
```javascript
await builton.products.update({body: {name: 'bar'}, urlParams: 'useless'});
```
or, if no other parameter is needed:
```javascript
await builton.products.update({body: {name: 'bar'}});
```



This is a bit cumbersome, this PR proposes a different way:
```javascript
await builton.products.update({name: 'bar'}, {urlParams: 'useless'});
```
or, if no other parameter is needed:
```javascript
await builton.products.update({name: 'bar'});
```

fixes: https://github.com/BuiltonDev/javascript-sdk/issues/51