### PR TITLE
Added function to authenticate after the SDK is instantiated.

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -60,6 +60,16 @@ class Builton {
   refreshBearerToken(newBearerToken) {
     this.request.bearerToken = newBearerToken;
   }
+
+  authenticate({ bearerToken, refreshTokenFn, body }) {
+    if (bearerToken) {
+      this.request.bearerToken = bearerToken;
+    }
+    if (refreshTokenFn) {
+      this.request.refreshBearerFn = refreshTokenFn;
+    }
+    return this.users.authenticate(body || {});
+  }
 }
 
 module.exports = Builton;


### PR DESCRIPTION
This change allows using the SDK without a bearerToken, and instantiate a user with a bearerToken at a later time.

```javascript
const builton = new Builton({
            apiKey: xxx
});

/// [...]
const products = builton.products.get().then((productPage) => {
            return productPage.current;
});

/// [...]
builton.authenticate({
            bearerToken,
            refreshTokenFn,
            body: {
                first_name: "foo"
            }
)};
```