### PR TITLE
Better error handling.

### DIFF
--- a/src/collection/objects/_objects.js
+++ b/src/collection/objects/_objects.js
@@ -59,7 +59,7 @@ class Component {
         }).then((res) => {
           const obj = parseJson(res, ResConstructor, json);
           return Promise.resolve({ res, obj });
-        }).catch((err) => Promise.reject(err));
+        }).catch((err) => Promise.reject(new Error.BadRequest(err)));
       } catch (err) {
         return Promise.reject(err);
       }

--- a/src/collection/resources/_resources.js
+++ b/src/collection/resources/_resources.js
@@ -46,7 +46,7 @@ class Components {
         }).then((res) => {
           const obj = parseJson(res, ResConstructor, json);
           return Promise.resolve({ res, obj });
-        }).catch((err) => Promise.reject(err));
+        }).catch((err) => Promise.reject(new Error.BadRequest(err)));
       } catch (err) {
         return Promise.reject(err);
       }

--- a/src/utils/error.js
+++ b/src/utils/error.js
@@ -1,9 +1,14 @@
 /* eslint-disable max-classes-per-file */
 class ExtendableError extends Error {
-  constructor(message) {
+  constructor(message, metadata) {
     super();
     this.message = message;
     this.name = this.constructor.name;
+    Object.entries(metadata).forEach(([key, value]) => {
+      if (!this[key]) {
+        this[key] = value;
+      }
+    });
   }
 }
 
@@ -31,9 +36,16 @@ class AbstractClass extends ExtendableError {
   }
 }
 
+class BadRequest extends ExtendableError {
+  constructor(requestError) {
+    super(requestError.response.body.message || 'Bad request', requestError);
+  }
+}
+
 module.exports = {
   MethodNeedsId,
   AbstractClass,
   MethodNeedsArg,
   NotImplemented,
+  BadRequest,
 };


### PR DESCRIPTION
This change update the way we handle errors.

Errors will now always return a message under the `error.message` key. We will only return our own errors instead of [SuperAgent](https://visionmedia.github.io/superagent/) errors.
This allows for having a human-readable and front facing error in all cases.